### PR TITLE
adjust for kernel 5.0.9

### DIFF
--- a/src/dir.c
+++ b/src/dir.c
@@ -849,7 +849,7 @@ static long fat_dir_ioctl(struct file *filp, unsigned int cmd,
 		return fat_generic_ioctl(filp, cmd, arg);
 	}
 
-	if (!access_ok(VERIFY_WRITE, d1, sizeof(struct __fat_dirent[2])))
+	if (!access_ok(d1, sizeof(struct __fat_dirent[2])))
 		return -EFAULT;
 	/*
 	 * Yes, we don't need this put_user() absolutely. However old
@@ -889,7 +889,7 @@ static long fat_compat_dir_ioctl(struct file *filp, unsigned cmd,
 		return fat_generic_ioctl(filp, cmd, (unsigned long)arg);
 	}
 
-	if (!access_ok(VERIFY_WRITE, d1, sizeof(struct compat_dirent[2])))
+	if (!access_ok(d1, sizeof(struct compat_dirent[2])))
 		return -EFAULT;
 	/*
 	 * Yes, we don't need this put_user() absolutely. However old

--- a/src/fatent.c
+++ b/src/fatent.c
@@ -35,6 +35,7 @@
 
 #include <linux/module.h>
 #include <linux/fs.h>
+#include <uapi/linux/mount.h>
 #ifndef VXEXT_FS
 //#include <linux/msdos_fs.h>
 #endif

--- a/src/inode.c
+++ b/src/inode.c
@@ -59,6 +59,7 @@
 #include <linux/blkdev.h>
 #include <asm/unaligned.h>
 #include <linux/iversion.h>
+#include <uapi/linux/mount.h>
 #include "fat.h"
 
 #ifndef CONFIG_FAT_DEFAULT_IOCHARSET

--- a/src/misc.c
+++ b/src/misc.c
@@ -40,6 +40,7 @@
 #include <linux/fs.h>
 #include <linux/buffer_head.h>
 #include <linux/time.h>
+#include <uapi/linux/mount.h>
 #include "fat.h"
 
 /*
@@ -275,7 +276,7 @@ void fat_time_unix2fat(struct msdos_sb_info *sbi, struct timespec64 *ts,
 		       __le16 *time, __le16 *date, u8 *time_cs)
 {
 	struct tm tm;
-	time_to_tm(ts->tv_sec,
+	time64_to_tm(ts->tv_sec,
 		   (sbi->options.tz_set ? sbi->options.time_offset :
 		   -sys_tz.tz_minuteswest) * SECS_PER_MIN, &tm);
 


### PR DESCRIPTION
access_ok only takes 2 parameters now, add mount.h.